### PR TITLE
Add own card count to avatar

### DIFF
--- a/public/html/gameplay.html
+++ b/public/html/gameplay.html
@@ -63,9 +63,20 @@
     <h3 id="timer">30s</h3>
 </div>
 <div id="player-avatars1"><div id="player-avatars2"></div></div>
-<div id="own-avatar"><button id="changeAvatar">
-    <i class="fas fa-rotate"></i>
-    </button></div>
+<div id="own-avatar" class="avatar">
+    <div class="cardHands">
+        <div class="avatar-row">
+            <h2 class="cardsleft"></h2>
+        </div>
+        <div class="avatar-row">
+            <span class="card small back"><span><span></span></span></span>
+            <span class="card small back"><span><span></span></span></span>
+        </div>
+    </div>
+    <button id="changeAvatar">
+        <i class="fas fa-rotate"></i>
+    </button>
+</div>
 <div id="player-hand-container"></div>
 <div id="yourTurn">
     Your turn in:

--- a/public/scripts/gameplay.js
+++ b/public/scripts/gameplay.js
@@ -515,6 +515,12 @@ function updateHandCounts(list) {
 
     const order = [2,0,1,3];
     playerOrientation = { [playerName]: 'self' };
+
+    const ownData = list.find(p => p.name === playerName);
+    const ownEl = document.querySelector('#own-avatar .cardsleft');
+    if (ownEl) {
+        ownEl.textContent = ownData ? `${ownData.count}x` : '';
+    }
     for (let i = 0; i < avatarSlots.length; i++) {
         const idx = order[i] ?? i;
         const slot = avatarSlots[idx];

--- a/public/styles/gameplay.css
+++ b/public/styles/gameplay.css
@@ -263,6 +263,30 @@
     top: 78%;
     left: 8%;
 
+    /* show card count to the left */
+    .cardHands {
+        right: 105%;
+        position: relative;
+        top: 20%;
+        display: flex;
+        flex-direction: column;
+
+        .avatar-row {
+            display: flex;
+            justify-content: center;
+
+            .cardsleft {
+                color: white;
+                -webkit-text-stroke: 0.07cqw black;
+                margin: 0;
+            }
+        }
+
+        .card {
+            width: 25%;
+        }
+    }
+
 }
 
 body#gameplay {


### PR DESCRIPTION
## Summary
- show player's own card count next to their avatar
- style own avatar card counter and include counter markup in gameplay page

## Testing
- `npm install`
- `npm run dev` *(fails: no tests provided)*

------
https://chatgpt.com/codex/tasks/task_e_68726db296308332932d992ca364969c