### PR TITLE
Handle hand-limit draw edge case

### DIFF
--- a/backend/logic/socketHandler.js
+++ b/backend/logic/socketHandler.js
@@ -422,6 +422,14 @@ export function setupSocket(io) {
             const count = game.drawStack > 0 ? game.drawStack : 1;
             if (game.hands[player].length + count > limit) {
                 socket.emit('hand-limit-reached');
+                if (game.drawStack > 0) {
+                    io.to(gameCode).emit('player-skipped', player);
+                    game.drawStack = 0;
+                }
+                const next = nextTurn(game);
+                handleUyesEnd(io, gameCode, game, player);
+                game.turnStartedAt = Date.now();
+                io.to(gameCode).emit('player-turn', { player: next, startedAt: game.turnStartedAt, drawStack: game.drawStack });
                 return;
             }
 


### PR DESCRIPTION
## Summary
- ensure drawing beyond the hand limit ends the player's turn

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6872751f96fc83328f9f7a757aa60c07