### PR TITLE
fix deck handling

### DIFF
--- a/backend/logic/socketHandler.js
+++ b/backend/logic/socketHandler.js
@@ -41,9 +41,8 @@ function createDeck(settings = {}) {
 }
 
 function dealInitialCards(game, count = 5, deckSettings = {}) {
-    const required = count * game.turnOrder.length + 1;
-    // If there are not enough cards, generate additional decks
-    while (game.deck.length < required) {
+    const minDeck = HAND_LIMIT * game.turnOrder.length + 1;
+    while (game.deck.length < minDeck) {
         game.deck = game.deck.concat(createDeck(deckSettings));
     }
     for (const player of game.turnOrder) {


### PR DESCRIPTION
## Summary
- ensure enough cards are present before dealing by using `HAND_LIMIT`
- keep discard reshuffle logic intact

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687295f2f6cc8332acfca57904c1699a