### PR TITLE
Remove verbose socket logs

### DIFF
--- a/backend/logic/socketHandler.js
+++ b/backend/logic/socketHandler.js
@@ -149,7 +149,7 @@ export function setupSocket(io) {
 
             socket.join(gameCode);
             socket.data.playerName = playerName; // 🔑 wichtig!
-            console.log(`➡️ ${playerName} betritt Lobby ${gameCode}`);
+
 
 
             if (!lobbies[gameCode].players.includes(playerName)) {
@@ -247,7 +247,6 @@ export function setupSocket(io) {
             io.to(newCode).emit("update-code", newCode);
         });
         socket.on("leave-lobby", (gameCode, playerName) => {
-            console.log(`🚪 ${playerName} verlässt Lobby ${gameCode}`);
 
             if (!lobbies[gameCode]) return;
 
@@ -401,6 +400,7 @@ export function setupSocket(io) {
 
             if (hand.length === 0) {
                 io.to(gameCode).emit('game-end', player);
+                console.log(`\u{1F3C1} Spiel in Lobby ${gameCode} beendet: ${player} hat gewonnen`);
                 delete lobby.game;
                 return;
             }
@@ -513,6 +513,7 @@ export function setupSocket(io) {
 
             if (lobby.players.length === 0) {
                 delete lobbies[gameCode];
+                console.log(`\u{1F6AB} Lobby ${gameCode} aufgelöst (keine Spieler)`);
             } else if (lobby.players.length === 1) {
                 const last = lobby.players[0];
                 for (const [_id, s] of io.sockets.sockets) {
@@ -522,12 +523,12 @@ export function setupSocket(io) {
                     }
                 }
                 delete lobbies[gameCode];
+                console.log(`\u{1F6AB} Lobby ${gameCode} aufgelöst (zu wenige Spieler)`);
             }
         });
 
 
         socket.on("disconnect", () => {
-            console.log(`🛑 Socket getrennt: ${socket.id}`);
             // Optional: du kannst hier aus der Lobby per socket-to-player Map löschen
         });
     });


### PR DESCRIPTION
## Summary
- stop logging join/leave/disconnect events
- log when a game ends
- log when a lobby gets dissolved if too few players remain

## Testing
- `npm install`
- `npm start` *(fails: Cannot find module)*

------
https://chatgpt.com/codex/tasks/task_e_6872965342d08332b2bc5dd9a4d68c47