### PR TITLE
Add font size for cards left

### DIFF
--- a/public/styles/gameplay.css
+++ b/public/styles/gameplay.css
@@ -180,6 +180,7 @@
             .cardsleft {
                 color: white;
                 -webkit-text-stroke: 0.07cqw black;
+                font-size: 2cqw;
                 margin: 0;
             }
 
@@ -278,6 +279,7 @@
             .cardsleft {
                 color: white;
                 -webkit-text-stroke: 0.07cqw black;
+                font-size: 2cqw;
                 margin: 0;
             }
         }


### PR DESCRIPTION
## Summary
- shrink the text showing remaining cards

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687298cc8e70833295491db567adf626