### PR TITLE
Improve landing redirect and UI tweaks

### DIFF
--- a/backend/routes.js
+++ b/backend/routes.js
@@ -13,6 +13,11 @@ const __dirname = path.dirname(__filename);
 
 const router = express.Router();
 
+// Redirect the base URL to the start page
+router.get('/', (req, res) => {
+    res.redirect('/start');
+});
+
 const htmlRoutes = {
     '/start': 'startSite.html',
     '/about': 'aboutPage.html',

--- a/public/html/aboutPage.html
+++ b/public/html/aboutPage.html
@@ -40,6 +40,11 @@
             <p>
                 We are a Group of students learning web developoment through creating this game. Our goal is to create a fun and engaging experience for players while also expanding our skills!
             </p>
+            <h2>Media Credits</h2>
+            <p>
+                Music and sound effects are provided by <a href="https://pixabay.com" target="_blank" rel="noopener">Pixabay</a>.
+                Avatar images, the start page graphics and the Eichberg image also originate from Pixabay.
+            </p>
         </div>
 </div>
 

--- a/public/styles/generalStyles.css
+++ b/public/styles/generalStyles.css
@@ -35,9 +35,11 @@ button, .button {
     box-shadow: 0 0.25em 0 #808080;
     background-color: var(--primary-yellow) ;
     border: solid 0.5cqh white;
+    border: solid 0.5vh white; /* Safari fallback */
     border-radius: 15%;
     font-weight: 800;
     font-size: 2.5cqw;
+    font-size: max(1rem, 2.5vw); /* Safari fallback */
     margin: 1em;
     aspect-ratio: 2.6/1;
 }

--- a/public/styles/lobby.css
+++ b/public/styles/lobby.css
@@ -92,9 +92,12 @@
 #refresh-code-button{
     flex-grow: 0;
     font-size: 1.5cqw;
-    width: 30%;
+    font-size: max(1rem, 1.5vw); /* Safari fallback */
+    width: auto;
+    padding: 0.5em 1em;
     text-align: center;
     margin: 2%;
+    white-space: nowrap;
 }
 
 
@@ -226,7 +229,8 @@
     }
     #refresh-code-button{
         font-size: 120%;
-        width: 35%;
+        width: auto;
+        padding: 0.5em 1em;
         margin-right: 5%;
     }
     #helpBtnLobby{

--- a/public/styles/startSite.css
+++ b/public/styles/startSite.css
@@ -44,6 +44,7 @@ div#menu {
         width: 15%;
         background-color: var(--primary-yellow);
         border: solid 0.5cqh white; /* ❗️cqh = container-height unit – bitte check Kompatibilität */
+        border: solid 0.5vh white; /* Safari fallback */
         border-radius: 15%;
         font-weight: 800;
         font-size: 3.5cqw; /* ❗️cqw = container-width unit – modern, aber nicht überall unterstützt */
@@ -51,9 +52,11 @@ div#menu {
 
     #start {
         width: 20%;
+        font-size: max(1rem, 3.5vw); /* Safari fallback */
         margin-left: 5%;
         margin-right: 5%;
         font-size: 4.5cqw; /* größerer Start-Button */
+        font-size: max(1.2rem, 4.5vw); /* Safari fallback */
     }
 }
 


### PR DESCRIPTION
## Summary
- redirect `/` to `/start`
- credit Pixabay on About page
- make refresh button responsive
- add Safari fallbacks for buttons

## Testing
- `npm run lint` *(fails: no-unused-vars in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_6874ef090c8483329491f603c6a4e3cb