### PR TITLE
Fix lobby text scaling

### DIFF
--- a/public/styles/lobby.css
+++ b/public/styles/lobby.css
@@ -91,7 +91,6 @@
 
 #refresh-code-button{
     flex-grow: 0;
-    font-size: 1.5cqw;
     font-size: max(1rem, 1.5vw); /* Safari fallback */
     width: auto;
     padding: 0.5em 1em;
@@ -123,18 +122,18 @@
         font-weight: 800;
         text-align:center;
         margin: 0;
-        font-size: 3cqw;
+        font-size: max(1.5rem, 3vw);
     }
 
 }
 #hostTag{
     color: black;
-    -webkit-text-stroke: 0.05cqw white;
+    -webkit-text-stroke: 0.05vw white;
     font-weight: 800;
     position: absolute;
     left: 30%;
     /*height: 25%;*/
-    font-size: 1.7cqw;
+    font-size: max(1rem, 1.7vw);
     +p{
         text-decoration: underline;
     }
@@ -160,12 +159,12 @@
             }
         }
         &.takenSlot{
-            font-size: 2cqw;
+            font-size: max(1rem, 2vw);
             +.removePlayerButton{
                 padding: initial;
                 box-shadow: initial;
                 background-color: lightgrey;
-                border: 0.25cqw solid dimgrey;
+                border: 0.25vw solid dimgrey;
                 font-weight: 800;
                 margin: initial;
 
@@ -175,8 +174,8 @@
                 transform: translateX(600%);
 
                 z-index: 5;
-                top: 0.1cqw;
-                font-size: 1cqw;
+                top: 0.1vw;
+                font-size: max(0.75rem, 1vw);
 
                 &:active{
                     transform: translateX(600%) scale(1.2);
@@ -201,7 +200,7 @@
     &.notFull{
         pointer-events: none;
         background-color: darkgrey;
-        border: solid 0.5cqh dimgrey;
+        border: solid 0.5vh dimgrey;
     }
 }
 


### PR DESCRIPTION
## Summary
- adjust lobby CSS to use viewport units
- ensure text elements scale when zoomed

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_6874f3d42cb88332ab982c3df1b59860