### PR TITLE
Fix cross-browser layout for intros

### DIFF
--- a/public/styles/gameplay.css
+++ b/public/styles/gameplay.css
@@ -8,9 +8,11 @@
     pointer-events: none;
     background-color: dimgrey;
     border: solid 0.5cqh darkgrey; /* ❗️cqh = container-height unit – bitte check Kompatibilität */
+    border: solid 0.5vh darkgrey; /* Safari fallback */
     border-radius: 15%;
     font-weight: 800;
     font-size: 2cqw;
+    font-size: max(1rem, 2vw);
 }
 
 #player-hand-container {

--- a/public/styles/introChooseLobby.css
+++ b/public/styles/introChooseLobby.css
@@ -17,7 +17,9 @@ button.introduction.chooseLobby{
     left: 75%;
     top: 80%;
     width: 7cqw; /* cqw = container width – kann bei kleinen Containern problematisch sein -> media queries */
+    width: 7vw;
     font-size: 1.5cqw;
+    font-size: max(1rem, 1.5vw);
 }
 
 

--- a/public/styles/introCreateGame.css
+++ b/public/styles/introCreateGame.css
@@ -21,31 +21,39 @@ button.introduction.createGame {
     left: 72%;
     top: 80%;
     width: 4cqw; /* cqw = container width – kann bei kleinen Containern problematisch sein -> media queries */
+    width: 4vw;
     font-size: 1cqw;
+    font-size: max(0.75rem, 1vw);
 }
 
 .speech.createGame {
     font-size: 1.9cqw;
+    font-size: max(1rem, 1.9vw);
 }
 
 #intro2 .speech.createGame {
     font-size: 2.2cqw;
+    font-size: max(1.2rem, 2.2vw);
 }
 
 #intro7 .speech.createGame {
     font-size: 1.8cqw;
+    font-size: max(1rem, 1.8vw);
 }
 
 #intro8 .speech.createGame {
     font-size: 1.8cqw;
+    font-size: max(1rem, 1.8vw);
 }
 
 #intro9 .speech.createGame {
     font-size: 3cqw;
+    font-size: max(1.2rem, 3vw);
 }
 
 #intro85 .speech.createGame {
     font-size: 2.3cqw;
+    font-size: max(1rem, 2.3vw);
 }
 
 
@@ -121,38 +129,47 @@ body:not(:has(#intro7[open])) {
 
     .speech.createGame {
         font-size: 4.3cqw;
+        font-size: max(1.5rem, 4.3vw);
     }
 
     button.introduction.createGame {
         left: 53%;
         top: 76%;
         width: 17cqw;
+        width: 17vw;
         font-size: 3.6cqw;
+        font-size: max(1.2rem, 3.6vw);
     }
 
     /* Schriftgröße für bestimmte Intros */
     #intro2 .speech.createGame {
         font-size: 4.8cqw;
+        font-size: max(1.5rem, 4.8vw);
     }
 
     #intro3 .speech.createGame {
         font-size: 4.8cqw;
+        font-size: max(1.5rem, 4.8vw);
     }
 
     #intro7 .speech.createGame {
         font-size: 3.9cqw;
+        font-size: max(1.2rem, 3.9vw);
     }
 
     #intro8 .speech.createGame {
         font-size: 4.1cqw;
+        font-size: max(1.2rem, 4.1vw);
     }
 
     #intro85 .speech.createGame {
         font-size: 5.5cqw;
+        font-size: max(1.5rem, 5.5vw);
     }
 
     #intro9 .speech.createGame {
         font-size: 6cqw;
+        font-size: max(1.5rem, 6vw);
     }
 
 }

--- a/public/styles/introStartSite.css
+++ b/public/styles/introStartSite.css
@@ -18,14 +18,17 @@
 /* Schriftgröße für bestimmte Intros */
 #intro4 .speech.startsite {
     font-size: 2.5cqw;
+    font-size: max(1rem, 2.5vw);
 }
 
 #intro5 .speech.startsite {
     font-size: 2.5cqw;
+    font-size: max(1rem, 2.5vw);
 }
 
 #intro65 .speech.startsite {
     font-size: 4.5cqw;
+    font-size: max(1.5rem, 4.5vw);
 }
 
 
@@ -34,8 +37,11 @@ button.introduction.startsite, .button.introduction.startsite{
     left: 75%;
     top: 80%;
     width: 7cqw; /* cqw = container width – kann bei kleinen Containern problematisch sein -> media queries */
+    width: 7vw;
     font-size: 2.5cqw;
+    font-size: max(1rem, 2.5vw);
     border: 0.25cqw solid black;
+    border: 0.25vw solid black;
 }
 
 

--- a/public/styles/startSite.css
+++ b/public/styles/startSite.css
@@ -48,6 +48,7 @@ div#menu {
         border-radius: 15%;
         font-weight: 800;
         font-size: 3.5cqw; /* ❗️cqw = container-width unit – modern, aber nicht überall unterstützt */
+        font-size: max(1rem, 3.5vw);
     }
 
     #start {
@@ -66,6 +67,7 @@ div#menu {
     aspect-ratio: 1/1;
     width: 25%;
     max-width: 100cqh; /* ❗️Auch hier: moderne Einheit – checke auf Mobilgeräten */
+    max-width: 100vh;
     background-image: url("../images/group.png");
     background-size: contain; /* Inhalt skalieren, ohne zu beschneiden */
 }


### PR DESCRIPTION
## Summary
- ensure fonts and buttons fall back to viewport units
- tweak group image width for consistency
- adjust UYES button style for browsers lacking container query units

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6874f8783b8c833296546925d863de0d